### PR TITLE
fix(naming): correct all misspelled occurrences of charybdis

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A remotely controlled fault injection file system.
     
 ##  How to run a Docker container
 
-All CharybisFS mounts will be available inside Docker container only.
+All CharybdisFS mounts will be available inside Docker container only.
 
     $ docker run -it --rm --device /dev/fuse --privileged -v $(pwd):/src charybdisfs bash
     

--- a/charybdisfs.py
+++ b/charybdisfs.py
@@ -26,7 +26,7 @@ import click
 import pyfuse3
 
 from core.faults import ErrorFault, SysCall
-from core.rest_api import start_charybdisfs_api_server, stop_charydisfs_api_server, DEFAULT_PORT
+from core.rest_api import start_charybdisfs_api_server, stop_charybdisfs_api_server, DEFAULT_PORT
 from core.operations import CharybdisOperations
 from core.configuration import Configuration
 from core.pyfuse3_types import wrap as pyfuse3_types_wrap
@@ -94,7 +94,7 @@ def start_charybdisfs(source: str,  # noqa: C901  # ignore "is too complex" mess
                              name="RestServerApi",
                              daemon=True)
         api_server_thread.start()
-        atexit.register(stop_charydisfs_api_server)
+        atexit.register(stop_charybdisfs_api_server)
 
     if mount:
         if source is None or target is None:

--- a/core/rest_api.py
+++ b/core/rest_api.py
@@ -78,5 +78,5 @@ def start_charybdisfs_api_server(port: int = DEFAULT_PORT) -> None:
     cherrypy.quickstart(root=CharybdisFsApiServer(), config=conf)
 
 
-def stop_charydisfs_api_server() -> None:
+def stop_charybdisfs_api_server() -> None:
     cherrypy.engine.exit()

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -18,7 +18,7 @@ import threading
 import pytest
 
 from client import CharybdisFsClient
-from core.rest_api import start_charybdisfs_api_server, stop_charydisfs_api_server, DEFAULT_PORT
+from core.rest_api import start_charybdisfs_api_server, stop_charybdisfs_api_server, DEFAULT_PORT
 
 
 @pytest.fixture(scope="module")
@@ -26,7 +26,7 @@ def start_api_server():
     threading.Thread(target=start_charybdisfs_api_server, daemon=True).start()
     time.sleep(1)
     yield
-    stop_charydisfs_api_server()
+    stop_charybdisfs_api_server()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
```sh
$ grep -ihEroI '[a-z_]*char[a-z_]+s[a-z_]*' --exclude-dir '.?*' --exclude-dir '__*' . | sort -u | grep -vi charybdis
$
```